### PR TITLE
Fix configfiles

### DIFF
--- a/scaleout/studio/templates/celery-worker-deployment.yaml
+++ b/scaleout/studio/templates/celery-worker-deployment.yaml
@@ -32,9 +32,21 @@ spec:
         imagePullPolicy: Always
         name: {{ .Release.Name }}-celery-worker
         resources: {}
+        volumeMounts:
+          - mountPath: /app/studio/setings.py
+            subPath: settings.py
+            name: {{ .Release.Name}}-settings-configmap
       {{- if .Values.imagePullSecret }}
       imagePullSecrets:
         - name: {{ .Values.imagePullSecret }}
       {{- end }}
       restartPolicy: Always
+      volumes:
+      - name: {{ .Release.Name}}-settings-configmap
+        configMap:
+          name: {{ .Release.Name}}-settings-configmap
+          items:
+          - key: settings.py
+            path: settings.py
+
 status: {}

--- a/scaleout/studio/templates/celery-worker-deployment.yaml
+++ b/scaleout/studio/templates/celery-worker-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         name: {{ .Release.Name }}-celery-worker
         resources: {}
         volumeMounts:
-          - mountPath: /app/studio/setings.py
+          - mountPath: /app/studio/settings.py
             subPath: settings.py
             name: {{ .Release.Name}}-settings-configmap
       {{- if .Values.imagePullSecret }}

--- a/scaleout/studio/templates/ingress-configmap.yaml
+++ b/scaleout/studio/templates/ingress-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-config-secret
+  name: nginx-config-configmap
 data:
   nginx.conf: |-
     user  nginx;

--- a/scaleout/studio/templates/ingress-deployment.yaml
+++ b/scaleout/studio/templates/ingress-deployment.yaml
@@ -26,21 +26,13 @@ spec:
         - name: GET_HOSTS_FROM
           value: dns
         image: registry.demo.scaleout.se/ingress:latest
-
         name: {{ .Release.Name }}-ingress
-        lifecycle:
-          postStart:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - |
-                  cp /var/secret/nginx.conf /etc/nginx/nginx.conf
         ports:
         - containerPort: 80
         volumeMounts:
-        - mountPath: /var/secret/
-          name: nginx-conf-secret
+        - mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+          name: nginx-conf
           readOnly: true
       {{- if .Values.imagePullSecret }}
       imagePullSecrets:
@@ -48,6 +40,9 @@ spec:
       {{- end }}
       restartPolicy: Always
       volumes:
-      - name: nginx-conf-secret
+      - name: nginx-conf
         configMap:
-          name: nginx-config-secret
+          name: nginx-config-configmap
+          items:
+          - key: nginx.conf
+            path: nginx.conf

--- a/scaleout/studio/templates/studio-settings-configmap.yaml
+++ b/scaleout/studio/templates/studio-settings-configmap.yaml
@@ -201,7 +201,7 @@ data:
     REDIS_DB = 0
     REDIS_HOST = os.environ.get('REDIS_PORT_6379_TCP_ADDR', 'redis')
 
-    CELERY_BROKER_URL = 'amqp://admin:sp3ctr4l@rabbit:5672//'
+    CELERY_BROKER_URL = 'amqp://{{ .Values.rabbit.username }}:{{ .Values.rabbit.password }}@{{ .Release.Name }}-rabbit:5672//'
     CELERY_RESULT_BACKEND = 'redis://%s:%d/%d' % (REDIS_HOST, REDIS_PORT, REDIS_DB)
     CELERY_TASK_SERIALIZER = 'json'
     CELERY_RESULT_SERIALIZER = 'json'

--- a/scaleout/studio/values.yaml
+++ b/scaleout/studio/values.yaml
@@ -70,4 +70,4 @@ postgres:
 # default credentials for rabbitmq. override in production!
 rabbit:
   username: admin
-  password: LJqEG9RE4Fd+ZbVWoJzZ+/IOQEI=
+  password: LJqEG9RE4FdZbVWoJzZIOQEI


### PR DESCRIPTION
- Fixed the default password for redis
- Fixed the configmap from mounting in init Lifecycle to mount prior to container spinup.
- Fixed the service name in settings.py which was not correctly configured.
- Fixed so that the correct settings.py was mounted on the celeryworker.

