### PR TITLE
Upgrade functionality in chart-controller, CLI command to upgrade rep…

### DIFF
--- a/scaleout/deploy/templates/project-deploy-function.yaml
+++ b/scaleout/deploy/templates/project-deploy-function.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ .Values.deployment.name }}-{{ .Values.deployment.version }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: {{ .Values.deployment.name }}-{{ .Values.deployment.version }}

--- a/scaleout/deploy/values.yaml
+++ b/scaleout/deploy/values.yaml
@@ -1,3 +1,5 @@
+replicas: 1
+
 global:
   domain: global.domain
 


### PR DESCRIPTION
STACKN-105

Upgrade endpoint in the chart controller
Deployment model extended with HelmResources object, which creates, upgrades, and deletes resources upon creation and deletion (via pre_save and pre_delete)
For testing: CLI command to update model deployment replica count:
stackn update deployment -n <model_name> -t <model_tag> -r <replicas>