### PR TITLE
HOLD: Updated ingress template to conform with latest definition

### DIFF
--- a/scaleout/stackn/templates/ingress-platform.yaml
+++ b/scaleout/stackn/templates/ingress-platform.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress
@@ -10,6 +10,7 @@ metadata:
   labels:
     io.kompose.service: {{ .Release.Name }}-ingress
 spec:
+  ingressClassName: public
   {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -27,11 +28,17 @@ spec:
         paths:
         - path: /
           backend:
-            serviceName: {{ $.Release.Name }}-studio
-            servicePort: 8080
+            service:
+              name: {{ $.Release.Name }}-studio
+              port:
+                number: 8080
+          pathType: ImplementationSpecific
         - path: /static/
           backend:
-            serviceName: {{ $.Release.Name }}-studio
-            servicePort: 8080
+            service:
+              name: {{ $.Release.Name }}-studio
+              port:
+                number: 8080
+          pathType: ImplementationSpecific
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Updating definitions to conform with >1.20.

- [x] networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
- [ ] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
- [ ] rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
- [ ] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding