### PR TITLE
Update action: using helm 3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
           
       - name: Install Helm
         run: |
-          url -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+          curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
           chmod 700 get_helm.sh
           ./get_helm.sh
           helm init --client-only


### PR DESCRIPTION
In relation to action build error: https://github.com/scaleoutsystems/charts/runs/4024083001?check_suite_focus=true

Previous action used an old version of helm.