### PR TITLE
Update action: removing outdated helm command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,6 @@ jobs:
           curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
           chmod 700 get_helm.sh
           ./get_helm.sh
-          helm init --client-only
 
       - name: Add chart dependencies
         run: |


### PR DESCRIPTION
Helm v3.7.0 does not have the init command anymore. This makes the build to fail.