### PR TITLE
Removing old helm init commands from action build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,6 @@ jobs:
           curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
           chmod 700 get_helm.sh
           ./get_helm.sh
-          helm init --client-only
 
       - name: Add chart dependencies
         run: |


### PR DESCRIPTION
Release helm chart action used an old version of helm. We have upgraded to v3.7.0 and `helm init` is now deprecated as a command.