### PR TITLE
Feature/SK-495 | Remove if debug for media mount in studio deployment manifest

### DIFF
--- a/scaleout/stackn/templates/studio-deployment.yaml
+++ b/scaleout/stackn/templates/studio-deployment.yaml
@@ -186,7 +186,7 @@ spec:
           items:
           - key: settings.py
             path: settings.py
-      {{ if .Values.studio.debug }}
+      {{ if .Values.studio.mountStudio }}
       - name: mediavol
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-{{ .Values.studio.media.storage.claimName }}

--- a/scaleout/stackn/templates/studio-deployment.yaml
+++ b/scaleout/stackn/templates/studio-deployment.yaml
@@ -186,7 +186,7 @@ spec:
           items:
           - key: settings.py
             path: settings.py
-      {{ if .Values.studio.mountStudio }}
+      {{ if .Values.studio.media.mountStudio }}
       - name: mediavol
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-{{ .Values.studio.media.storage.claimName }}

--- a/scaleout/stackn/templates/studio-deployment.yaml
+++ b/scaleout/stackn/templates/studio-deployment.yaml
@@ -186,7 +186,7 @@ spec:
           items:
           - key: settings.py
             path: settings.py
-      {{ if .Values.studio.media.mountStudio }}
+      {{ if .Values.studio.media.storage.mountStudio }}
       - name: mediavol
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-{{ .Values.studio.media.storage.claimName }}

--- a/scaleout/stackn/values.yaml
+++ b/scaleout/stackn/values.yaml
@@ -104,6 +104,7 @@ studio:
       size: "5Gi"
       accessModes: ReadWriteMany
       claimName: studio-media
+      mountStudio: false
     mount_path: /app/media/
   superUser: admin
   superuserPassword: ""


### PR DESCRIPTION
Previously we only mounted media to studio pod if debug=True, we want to mount media to both studio and nginx (which require accessmode RWX). Added new value studio.media.storage.mountStudio which can be set to true or false, true will mount media PVC to studio pod. 