### PR TITLE
Bug/SK-593 | Settings config map needs to include system app

### DIFF
--- a/scaleout/stackn/templates/studio-settings-configmap.yaml
+++ b/scaleout/stackn/templates/studio-settings-configmap.yaml
@@ -70,7 +70,7 @@ data:
         "monitor",
         "apps",
         "api",
-        "customtags",
+        "system",
     ]
 
     {{ if .Values.studio.custom_apps.enabled }}
@@ -306,7 +306,8 @@ data:
         'models': 'studio.migrations.models',
         'monitor': 'studio.migrations.monitor',
         'portal': 'studio.migrations.portal',
-        'projects': 'studio.migrations.projects'
+        'projects': 'studio.migrations.projects',
+        'system': 'studio.migrations.system'
     }
 
     {{ if .Values.studio.custom_migrations.enabled }}


### PR DESCRIPTION
- Updated config map to include new app systems (also including migrations) 
- Removed usage of customtags which no longer exists