### PR TITLE
Feature/SK-1350 | Changed how we handle app versions

### DIFF
--- a/scaleout/stackn/Chart.yaml
+++ b/scaleout/stackn/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.14.5"
+appVersion: "0.17.0"
 description: A Helm chart for deploying studio
 name: studio
-version: 0.5.4
+version: 0.5.6
 maintainers:
   - email: fredrik@scaleoutsystems.com
     name: Fredrik Wrede

--- a/scaleout/stackn/templates/deployment-frontend.yaml
+++ b/scaleout/stackn/templates/deployment-frontend.yaml
@@ -42,7 +42,7 @@ spec:
           value: "development"
         {{ end }}
         - name: API_URL
-          value: "http://frontend-frontend:8080"
+          value: "http://studio-studio:8080"
         - name: NEXT_PUBLIC_USE_FEDN_PROXY
           value: "true"
         {{ if .Values.frontend.recaptcha.enabled }}

--- a/scaleout/stackn/templates/deployment-frontend.yaml
+++ b/scaleout/stackn/templates/deployment-frontend.yaml
@@ -1,29 +1,79 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: fedn-frontend-dev
+  name: fedn-frontend
 spec:
-  replicas: 1
+  replicas: {{ .Values.frontend.replicas }}
   selector:
     matchLabels:
       app: fedn-frontend
+  strategy:
+    type: {{ .Values.frontend.strategy.type }}
   template:
     metadata:
       labels:
         app: fedn-frontend
     spec:
+      automountServiceAccountToken: {{ .Values.frontend.automountServiceAccountToken }}
+      {{- if .Values.frontend.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.frontend.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.frontend.securityContext.runAsGroup }}
+        fsGroup:  {{ .Values.frontend.securityContext.fsGroup }}
+        allowPrivilegeEscalation: {{ .Values.frontend.securityContext.allowPrivilegeEscalation }}
+        privileged: {{ .Values.frontend.securityContext.privileged }}
+        readOnlyRootFilesystem: {{ .Values.frontend.securityContext.readOnlyRootFilesystem }}
+        runAsNonRoot: {{ .Values.frontend.securityContext.runAsNonRoot }}
+        capabilities:
+          drop:
+            - ALL
+      {{- end }}
       imagePullSecrets:
-      - name: harborsecret
+      - name: {{ .Values.frontend.image.pullSecret }}
       containers:
       - name: fedn-frontend
-        imagePullPolicy: Always
-        image: harbor.scaleoutsystems.com/stefan-dev/studio-front:latest # Replace with your image name
+        imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+        image: {{ .Values.frontend.image.repository | default "harbor.scaleoutsystems.com/fedn/fedn-front-end:main" }}
         ports:
         - containerPort: 3000
         env:
-        # - name: NODE_ENV
-        #   value: "development" # Ensures it's in dev mode
+        {{ if .Values.frontend.debug }}
+        - name: NODE_ENV
+          value: "development"
+        {{ end }}
         - name: API_URL
-          value: "http://studio-studio:8080"
+          value: "http://frontend-frontend:8080"
         - name: NEXT_PUBLIC_USE_FEDN_PROXY
           value: "true"
+        {{ if .Values.frontend.recaptcha.enabled }}
+        - name: RECAPTCHA_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.frontend.recaptcha.existingSecret }}
+              key: {{ .Values.frontend.recaptcha.existingSecretKey }}
+        - name: NEXT_PUBLIC_RECAPTCHA_SITE_KEY
+          value: {{ .Values.frontend.recaptcha.siteKey }}
+        - name: NEXT_PUBLIC_RECAPTCHA_ACTION)
+          value: {{ .Values.frontend.recaptcha.action }}
+        {{ end }}
+        resources:
+          limits:
+            cpu: {{ .Values.frontend.resources.limits.cpu }}
+            memory: {{ .Values.frontend.resources.limits.memory }}
+          requests:
+            cpu: {{ .Values.frontend.resources.requests.cpu }}
+            memory: {{ .Values.frontend.resources.requests.memory }}
+         {{- if .Values.frontend.readinessProbe.enabled }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.frontend.readinessProbe.tcpSocket.port }}
+          initialDelaySeconds: {{ .Values.frontend.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.frontend.readinessProbe.periodSeconds }}
+        {{- end }}
+        {{- if .Values.frontend.livenessProbe.enabled }}
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.frontend.livenessProbe.tcpSocket.port }}
+          initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.frontend.livenessProbe.periodSeconds }}
+        {{- end }}

--- a/scaleout/stackn/templates/deployment-frontend.yaml
+++ b/scaleout/stackn/templates/deployment-frontend.yaml
@@ -42,7 +42,9 @@ spec:
           value: "development"
         {{ end }}
         - name: API_URL
-          value: "http://studio-studio:8080"
+          value: {{ printf "http://%s-%s:8080" .Release.Name .Values.studio.servicename | quote }}
+        - name: NEXT_PUBLIC_API_DOMAIN
+          value: {{ .Values.domain | quote }}
         - name: NEXT_PUBLIC_USE_FEDN_PROXY
           value: "true"
         {{ if .Values.frontend.recaptcha.enabled }}

--- a/scaleout/stackn/templates/deployment-frontend.yaml
+++ b/scaleout/stackn/templates/deployment-frontend.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fedn-frontend-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fedn-frontend
+  template:
+    metadata:
+      labels:
+        app: fedn-frontend
+    spec:
+      imagePullSecrets:
+      - name: harborsecret
+      containers:
+      - name: fedn-frontend
+        imagePullPolicy: Always
+        image: harbor.scaleoutsystems.com/stefan-dev/studio-front:latest # Replace with your image name
+        ports:
+        - containerPort: 3000
+        env:
+        # - name: NODE_ENV
+        #   value: "development" # Ensures it's in dev mode
+        - name: API_URL
+          value: "http://studio-studio:8080"
+        - name: NEXT_PUBLIC_USE_FEDN_PROXY
+          value: "true"

--- a/scaleout/stackn/templates/event-listener-deployment.yaml
+++ b/scaleout/stackn/templates/event-listener-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets.name }}
       containers:
-      - image: {{ .Values.eventListener.image.repository }}
+      - image: "{{ .Values.eventListener.image.repository | default "harbor.scaleoutsystems.com/studio/studio-kube-controller:{{ .Chart.AppVersion }}" }}"
         imagePullPolicy: {{ .Values.eventListener.image.pullPolicy }}
         name: studio-event-listener
         resources:

--- a/scaleout/stackn/templates/event-listener-deployment.yaml
+++ b/scaleout/stackn/templates/event-listener-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets.name }}
       containers:
-      - image: "{{ .Values.eventListener.image.repository | default "harbor.scaleoutsystems.com/studio/studio-kube-controller:{{ .Chart.AppVersion }}" }}"
+      - image: "{{ .Values.eventListener.image.repository | default "harbor.scaleoutsystems.com/studio/studio-kube-controller:{{ .Chart.appVersion }}" }}"
         imagePullPolicy: {{ .Values.eventListener.image.pullPolicy }}
         name: studio-event-listener
         resources:

--- a/scaleout/stackn/templates/event-listener-deployment.yaml
+++ b/scaleout/stackn/templates/event-listener-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets.name }}
       containers:
-      - image: "{{ .Values.eventListener.image.repository | default "harbor.scaleoutsystems.com/studio/studio-kube-controller:{{ .Chart.appVersion }}" }}"
+      - image: "{{ .Values.eventListener.image.repository | default "harbor.scaleoutsystems.com/studio/studio-kube-controller:{{ .Chart.AppVersion }}" }}"
         imagePullPolicy: {{ .Values.eventListener.image.pullPolicy }}
         name: studio-event-listener
         resources:

--- a/scaleout/stackn/templates/ingress-frontend.yaml
+++ b/scaleout/stackn/templates/ingress-frontend.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fednnext-ingress
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: fedn.test.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: fedn-frontend-service
+                port:
+                  number: 80
+  # TLS can be configured here if needed
+  # tls:
+  # - hosts:
+  #     - fednnext.test.local
+  #   secretName: my-tls-secret

--- a/scaleout/stackn/templates/ingress-frontend.yaml
+++ b/scaleout/stackn/templates/ingress-frontend.yaml
@@ -1,23 +1,23 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: fednnext-ingress
-  namespace: default
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-spec:
-  ingressClassName: nginx
-  rules:
-    - host: fedn.test.local
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: fedn-frontend-service
-                port:
-                  number: 80
+# apiVersion: networking.k8s.io/v1
+# kind: Ingress
+# metadata:
+#   name: fednnext-ingress
+#   namespace: default
+#   annotations:
+#     nginx.ingress.kubernetes.io/rewrite-target: /
+# spec:
+#   ingressClassName: nginx
+#   rules:
+#     - host: fedn.test.local
+#       http:
+#         paths:
+#           - path: /
+#             pathType: Prefix
+#             backend:
+#               service:
+#                 name: fedn-frontend-service
+#                 port:
+#                   number: 80
   # TLS can be configured here if needed
   # tls:
   # - hosts:

--- a/scaleout/stackn/templates/ingress-frontend.yaml
+++ b/scaleout/stackn/templates/ingress-frontend.yaml
@@ -1,25 +1,32 @@
-# apiVersion: networking.k8s.io/v1
-# kind: Ingress
-# metadata:
-#   name: fednnext-ingress
-#   namespace: default
-#   annotations:
-#     nginx.ingress.kubernetes.io/rewrite-target: /
-# spec:
-#   ingressClassName: nginx
-#   rules:
-#     - host: fedn.test.local
-#       http:
-#         paths:
-#           - path: /
-#             pathType: Prefix
-#             backend:
-#               service:
-#                 name: fedn-frontend-service
-#                 port:
-#                   number: 80
-  # TLS can be configured here if needed
-  # tls:
-  # - hosts:
-  #     - fednnext.test.local
-  #   secretName: my-tls-secret
+{{- if .Values.frontend.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fedn-frontend-ingress
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+   {{- range .Values.frontend.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $.Values.frontend.service.name }}
+                port:
+                  number: {{ $.Values.frontend.service.port }}
+    {{- end }}
+  {{- if .Values.frontend.ingress.tls.enabled }}
+  tls:
+  - hosts:
+      {{- range .Values.frontend.ingress.tls.hosts }}
+      - {{ . | quote }}
+      {{- end }}
+    secretName: {{ .Values.frontend.ingress.tls.existingSecret }}
+  {{- end }}
+{{- end }}

--- a/scaleout/stackn/templates/ingress-platform.yaml
+++ b/scaleout/stackn/templates/ingress-platform.yaml
@@ -41,6 +41,7 @@ spec:
               port:
                 number: 8080
           pathType: ImplementationSpecific
+        {{- if $.Values.studio.static.enabled }}
         - path: /static/
           backend:
             service:
@@ -55,6 +56,7 @@ spec:
               port:
                 number: 8081
           pathType: ImplementationSpecific
+        {{- end }}
   {{- end }}
 {{- end }}
 

--- a/scaleout/stackn/templates/ingress-platform.yaml
+++ b/scaleout/stackn/templates/ingress-platform.yaml
@@ -30,6 +30,13 @@ spec:
         - path: /
           backend:
             service:
+              name: fedn-frontend-service
+              port:
+                number: 80
+          pathType: ImplementationSpecific
+        - path: /api/
+          backend:
+            service:
               name: {{ $.Release.Name }}-studio
               port:
                 number: 8080

--- a/scaleout/stackn/templates/mongodb-backup-job.yaml
+++ b/scaleout/stackn/templates/mongodb-backup-job.yaml
@@ -32,7 +32,7 @@ spec:
             - name: S3PORT
               value: {{ .Values.studio.minio_backup.port | quote }}
             - name : S3BUCKET
-              value: studio-mongodb-backups
+              value: {{ .Values.studio.minio_backup.mongodb_bucket }}
             - name: S3ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/scaleout/stackn/templates/nginx-conf.yaml
+++ b/scaleout/stackn/templates/nginx-conf.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.studio.static.enabled }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -21,3 +22,4 @@ data:
             }
         }
     }
+{{ end }}

--- a/scaleout/stackn/templates/nginx-deployment.yaml
+++ b/scaleout/stackn/templates/nginx-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           name: {{ .Release.Name }}-static-config
       containers:
       - name: static
-        image: "{{ .Values.studio.static.image | default "harbor.scaleoutsystems.com/studio/studio-nginx:{{ .Chart.AppVersion }}" }}"
+        image: '{{ .Values.studio.static.image | default (printf "harbor.scaleoutsystems.com/studio/studio-nginx:%s" .Chart.AppVersion) }}'
         imagePullPolicy: {{ .Values.studio.static.pullPolicy }}
         # securityContext:
         #   runAsUser: 101

--- a/scaleout/stackn/templates/nginx-deployment.yaml
+++ b/scaleout/stackn/templates/nginx-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           name: {{ .Release.Name }}-static-config
       containers:
       - name: static
-        image: "{{ .Values.studio.static.image | default "harbor.scaleoutsystems.com/studio/studio-nginx:{{ .Chart.appVersion }}" }}"
+        image: "{{ .Values.studio.static.image | default "harbor.scaleoutsystems.com/studio/studio-nginx:{{ .Chart.AppVersion }}" }}"
         imagePullPolicy: {{ .Values.studio.static.pullPolicy }}
         # securityContext:
         #   runAsUser: 101

--- a/scaleout/stackn/templates/nginx-deployment.yaml
+++ b/scaleout/stackn/templates/nginx-deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.studio.static.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -57,3 +58,4 @@ spec:
             memory: {{ .Values.studio.static.resources.requests.memory }}
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets.name }}
+{{ end }}

--- a/scaleout/stackn/templates/nginx-deployment.yaml
+++ b/scaleout/stackn/templates/nginx-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           name: {{ .Release.Name }}-static-config
       containers:
       - name: static
-        image: {{ .Values.studio.static.image }}
+        image: "{{ .Values.studio.static.image | default "harbor.scaleoutsystems.com/studio/studio-nginx:{{ .Chart.appVersion }}" }}"
         imagePullPolicy: {{ .Values.studio.static.pullPolicy }}
         # securityContext:
         #   runAsUser: 101

--- a/scaleout/stackn/templates/nginx-service.yaml
+++ b/scaleout/stackn/templates/nginx-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.studio.static.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
     pod: nginx-static
 status:
   loadBalancer: {}
+{{ end }}

--- a/scaleout/stackn/templates/service-frontend.yaml
+++ b/scaleout/stackn/templates/service-frontend.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fedn-frontend-service
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: 3000
+  selector:
+    app: fedn-frontend

--- a/scaleout/stackn/templates/service-frontend.yaml
+++ b/scaleout/stackn/templates/service-frontend.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: fedn-frontend-service
+  name: {{ .Values.frontend.service.name }}
 spec:
   type: LoadBalancer
   ports:
-    - port: 80
+    - port: {{ .Values.frontend.service.port }}
       targetPort: 3000
   selector:
     app: fedn-frontend

--- a/scaleout/stackn/templates/studio-deployment.yaml
+++ b/scaleout/stackn/templates/studio-deployment.yaml
@@ -345,7 +345,7 @@ spec:
         - name: HARBOR_PATH
           value: {{ .Values.studio.project.path }}
         {{ end }}
-        image: "{{ .Values.studio.image.repository | default "harbor.scaleoutsystems.com/studio/studio:{{ .Chart.AppVersion }}" }}"
+        image: "{{ .Values.studio.image.repository | default "harbor.scaleoutsystems.com/studio/studio:{{ .Chart.appVersion }}" }}"
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}
         name: {{ .Release.Name }}-studio
         resources:

--- a/scaleout/stackn/templates/studio-deployment.yaml
+++ b/scaleout/stackn/templates/studio-deployment.yaml
@@ -345,7 +345,7 @@ spec:
         - name: HARBOR_PATH
           value: {{ .Values.studio.project.path }}
         {{ end }}
-        image: "{{ .Values.studio.image.repository | default "harbor.scaleoutsystems.com/studio/studio:{{ .Chart.appVersion }}" }}"
+        image: "{{ .Values.studio.image.repository | default "harbor.scaleoutsystems.com/studio/studio:{{ .Chart.AppVersion }}" }}"
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}
         name: {{ .Release.Name }}-studio
         resources:

--- a/scaleout/stackn/templates/studio-deployment.yaml
+++ b/scaleout/stackn/templates/studio-deployment.yaml
@@ -345,7 +345,7 @@ spec:
         - name: HARBOR_PATH
           value: {{ .Values.studio.project.path }}
         {{ end }}
-        image: {{ .Values.studio.image.repository }}
+        image: "{{ .Values.studio.image.repository | default "harbor.scaleoutsystems.com/studio/studio:{{ .Chart.AppVersion }}" }}"
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}
         name: {{ .Release.Name }}-studio
         resources:

--- a/scaleout/stackn/templates/studio-deployment.yaml
+++ b/scaleout/stackn/templates/studio-deployment.yaml
@@ -121,7 +121,7 @@ spec:
           value: "false"
         {{ end }}
         - name: VERSION
-          value: {{ .Values.studio.version | quote  }}
+          value: "{{ .Values.studio.version | default .Chart.AppVersion  }}"
         - name: DEFAULT_FROM_EMAIL
           value: {{ .Values.studio.emailService.smtpEmailFrom | quote}}
         - name: SESSION_COOKIE_DOMAIN
@@ -345,7 +345,7 @@ spec:
         - name: HARBOR_PATH
           value: {{ .Values.studio.project.path }}
         {{ end }}
-        image: "{{ .Values.studio.image.repository | default "harbor.scaleoutsystems.com/studio/studio:{{ .Chart.AppVersion }}" }}"
+        image: '{{ .Values.studio.image.repository | default (printf "harbor.scaleoutsystems.com/studio/studio:%s" .Chart.AppVersion) }}'  
         imagePullPolicy: {{ .Values.studio.image.pullPolicy }}
         name: {{ .Release.Name }}-studio
         resources:

--- a/scaleout/stackn/values.yaml
+++ b/scaleout/stackn/values.yaml
@@ -99,6 +99,16 @@ frontend:
     periodSeconds: 20
   automountServiceAccountToken: false # automount service account token for frontend
   debug: false # dev mode for frontend
+  ingress: # ingress for frontend
+    enabled: true # enable ingress for frontend
+    hosts:  
+      - "fedn.scaleoutsystems.com" # host for frontend
+    tls: # tls for frontend
+      enabled: true # enable tls for frontend
+      hosts:
+        - "fedn.scaleoutsystems.com"
+      existingSecret: "fedn-tls" # name of existing secret containing tls certificate
+
 
 
 studio: # studio values

--- a/scaleout/stackn/values.yaml
+++ b/scaleout/stackn/values.yaml
@@ -133,6 +133,7 @@ studio: # studio values
   csrf_trusted_origins: # csrf trusted origins for studio. Add extra trusted origins for CSRF protection.
   kube_api_request_timeout: 1 # timeout for kubernetes api requests, such as request to create/delete resources
   static: # static values for studio, ngnix server for serving static files and media files
+    enabled: false # enable static for studio
     replicas: 1 # number of static replicas
     strategy: # strategy for static
       type: Recreate # type of strategy

--- a/scaleout/stackn/values.yaml
+++ b/scaleout/stackn/values.yaml
@@ -52,6 +52,54 @@ networkPolicy: # network policy for stackn
     - 172.0.0.0/20
   ingress_controller_namespace: kube-system # namespace for ingress controller
 
+frontend:
+  service: 
+    name: fedn-frontend-service # name of frontend service
+    port: 80 # port for frontend service
+  replicas: 1 # number of frontend replicas
+  strategy: # strategy for frontend
+    type: RollingUpdate # type of strategy
+  image: # image for frontend
+    repository: harbor.scaleoutsystems.com/fedn/fedn-front-end:main
+    pullPolicy: Always # pull policy for frontend
+    pullSecret: harborsecret # pull secret for frontend
+  resources: # resources for frontend
+    limits: # limits for frontend
+      cpu: "1000m" # cpu limit for frontend
+      memory: "1Gi" # memory limit for frontend
+    requests: # requests for frontend
+      cpu: "100m" # cpu request for frontend
+      memory: "128Mi" # memory request for frontend
+  recaptcha: # recaptcha for frontend
+    enabled: false # enable recaptcha for frontend
+    existingSecret: "google-recaptcha-secret" # name of existing secret containing recaptcha secret
+    existingSecretKey: "key" # key in existing secret containing recaptcha secret
+    siteKey: "" # site key for recaptcha
+    action: "userRegister" # action for recaptcha
+  securityContext: # security context for frontend
+    enabled: true
+    runAsUser: 1001
+    runAsGroup: 1001
+    fsGroup: 1001
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    privileged: false
+  readinessProbe: # readiness probe for frontend
+    enabled: true
+    tcpSocket:
+      port: 3000
+    initialDelaySeconds: 20
+    periodSeconds: 10
+  livenessProbe: # liveness probe for frontend
+    enabled: true
+    tcpSocket:
+      port: 3000
+    initialDelaySeconds: 20
+    periodSeconds: 20
+  automountServiceAccountToken: false # automount service account token for frontend
+  debug: false # dev mode for frontend
+
 
 studio: # studio values
   servicename: studio # name of studio service

--- a/scaleout/stackn/values.yaml
+++ b/scaleout/stackn/values.yaml
@@ -114,7 +114,7 @@ studio: # studio values
   superuserEmail: admin@test.com
   eventListenerUsername: ""
   eventListenerUserPassword: ""
-  version: studio
+  #version: studio
   securityContext:
     enabled: true
     runAsUser: 1000

--- a/scaleout/stackn/values.yaml
+++ b/scaleout/stackn/values.yaml
@@ -88,7 +88,7 @@ studio: # studio values
     replicas: 1 # number of static replicas
     strategy: # strategy for static
       type: Recreate # type of strategy
-    image: harbor.scaleoutsystems.com/studio/studio-nginx:0.10.0-beta.1 # image for static
+    # image: harbor.scaleoutsystems.com/studio/studio-nginx:0.17.0 # image for static, use this value if you want to override default (usually you should not)
     pullPolicy: IfNotPresent # pull policy for static
     resources: # resources for static
       limits: # limits for static
@@ -98,7 +98,7 @@ studio: # studio values
         cpu: "100m" # cpu request for static
         memory: "256Mi" # memory request for static
   image: #tell which image to deploy for studio
-    repository: harbor.scaleoutsystems.com/studio/studio:0.10.0-beta.1 #This image can be built from Dockerfile inside stackn/components/studio (https://github.com/scaleoutsystems/stackn)
+    repository: harbor.scaleoutsystems.com/studio/studio:0.17.0 # This image can be built from Dockerfile inside stackn/components/studio (https://github.com/scaleoutsystems/stackn)
     pullPolicy: IfNotPresent # used to ensure that each time we redeploy always pull the latest image
   resources:
     limits:
@@ -194,6 +194,7 @@ studio: # studio values
     host: http://minio-system-hl.minio-system.svc.cluster.local
     secretName: minio-system-user-0
     port: "9000"
+    mongodb_bucket: studio-mongodb-backups
 
   harbor:
     enabled: true
@@ -300,7 +301,7 @@ eventListener:
   appStatusEndpoint: "api/internal/app/status"
   appStatusesEndpoint: "api/internal/app/statuses"
   image: 
-    repository: harbor.scaleoutsystems.com/studio/studio-kube-controller:0.10.0-beta.1
+    repository: harbor.scaleoutsystems.com/studio/studio-kube-controller:main
     pullPolicy: IfNotPresent # used to ensure that each time we redeploy always pull the latest image
 
 


### PR DESCRIPTION
If studio (and corresponding static) image is not set in values, then there is a default value set with the image tag based on the appVersion in chart.yaml. This is so that customers won't have to explicitly set the image version when deploying or upgrading, it will be baked into the chart.